### PR TITLE
Updates to Stackage LTS22 and adds a Nix build

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# this line sources your `.envrc.local` file
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 cloudwatcher.cabal
 .stack-work/
+/.envrc.local
+/.direnv/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cloudwatcher.cabal
 .stack-work/
 /.envrc.local
 /.direnv/
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719223410,
+        "narHash": "sha256-jtIo8xR0Zp4SalIwmD+OdCwHF4l7OU6PD63UUK4ckt4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "efb39c6052f3ce51587cf19733f5f4e5d515aa13",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
       # https://github.com/cachix/pre-commit-hooks.nix/pull/122
       defaultSystems = [
         "aarch64-linux"
-        # "aarch64-darwin"
+        "aarch64-darwin"
         "i686-linux"
         "x86_64-darwin"
         "x86_64-linux"
@@ -67,13 +67,13 @@
 
           defaultPackage = packages.cloudwatcher;
 
-          # apps = {
-          #   web-server = {
-          #     type = "app";
-          #     program = "${self.packages.${system}.webserver-backend}/bin/web-server";
-          #   };
+          apps = {
+            cloudwatcher = {
+              type = "app";
+              program = "${self.packages.${system}.cloudwatcher}/bin/cloudwatcher";
+            };
 
-          #   default = self.apps.${system}.web-server;
-          # };
+            default = self.apps.${system}.cloudwatcher;
+          };
         });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "TUI for reviewing error logs from AWS Cloudwatch ";
+
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
+    flake-utils.url = github:numtide/flake-utils;
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      ghcVersion = "965";
+      compiler = "ghc${ghcVersion}";
+
+      # default systems compatible with pre-commit-hooks.nix
+      # https://github.com/cachix/pre-commit-hooks.nix/pull/122
+      defaultSystems = [
+        "aarch64-linux"
+        # "aarch64-darwin"
+        "i686-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+    in
+    flake-utils.lib.eachSystem defaultSystems
+      (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          hsPkgs = pkgs.haskell.packages.${compiler}.override {
+            overrides = hfinal: hprev: {
+              cloudwatcher = hfinal.callCabal2nix "cloudwatcher" ./. { };
+            };
+          };
+
+          stack = pkgs.symlinkJoin {
+            # Stack will be available as the usual `stack` in terminal
+            name = "stack";
+            paths = [ pkgs.stack ];
+            buildInputs = [ pkgs.makeWrapper ];
+            postBuild = ''
+              wrapProgram $out/bin/stack \
+                --add-flags "\
+                  --no-nix \
+                  --system-ghc \
+                  --no-install-ghc \
+                "
+            '';
+          };
+
+        in
+        rec {
+          devShell = pkgs.mkShell {
+            buildInputs = [
+              pkgs.cabal-install
+              pkgs.haskell.compiler.${compiler}
+              pkgs.nixpkgs-fmt
+              pkgs.ormolu
+              pkgs.zlib
+              pkgs.zlib.dev
+              stack
+            ];
+          };
+
+          formatter = pkgs.nixpkgs-fmt;
+          packages = flake-utils.lib.flattenTree {
+            cloudwatcher = hsPkgs.cloudwatcher;
+          };
+
+          defaultPackage = packages.cloudwatcher;
+
+          # apps = {
+          #   web-server = {
+          #     type = "app";
+          #     program = "${self.packages.${system}.webserver-backend}/bin/web-server";
+          #   };
+
+          #   default = self.apps.${system}.web-server;
+          # };
+        });
+}

--- a/package.yaml
+++ b/package.yaml
@@ -62,6 +62,7 @@ dependencies:
     - time
     - vector
     - vty
+    - vty-crossplatform
 
 
 library:

--- a/src/Lib/Events.hs
+++ b/src/Lib/Events.hs
@@ -3,7 +3,7 @@ module Lib.Events
     , WorkerEvent(..)
     ) where
 
-import           Network.AWS.CloudWatchLogs     ( FilteredLogEvent
+import           Amazonka.CloudWatchLogs     ( FilteredLogEvent
                                                 , LogGroup
                                                 , LogStream
                                                 )

--- a/src/Lib/Main.hs
+++ b/src/Lib/Main.hs
@@ -20,9 +20,8 @@ import           Control.Monad                  ( forever
                                                 , void
                                                 )
 import           Data.Version                   ( showVersion )
-import           Graphics.Vty                   ( mkVty
-                                                , standardIOConfig
-                                                )
+import           Graphics.Vty.Config            ( defaultConfig )
+import           Graphics.Vty.CrossPlatform     ( mkVty )
 import           System.Console.CmdArgs         ( (&=)
                                                 , Data
                                                 , Typeable
@@ -53,9 +52,9 @@ run Args { lookback } = do
     st         <- initialState
     brickQueue <- newBChan 100
     withAsync (startWorker brickQueue $ asyncQueue st) $ \_ -> do
-        vty <- standardIOConfig >>= mkVty
+        vty <- mkVty defaultConfig
         void $ customMain vty
-                          (standardIOConfig >>= mkVty)
+                          (mkVty defaultConfig)
                           (Just brickQueue)
                           app
                           st

--- a/src/Lib/Worker.hs
+++ b/src/Lib/Worker.hs
@@ -10,8 +10,7 @@ import           Control.Lens                   ( (^.) )
 import           Data.Time                      ( addUTCTime
                                                 , getCurrentTime
                                                 )
-import           Network.AWS.CloudWatchLogs
-                                         hiding ( getLogEvents )
+import           Amazonka.CloudWatchLogs.Types
 
 import           Lib
 import           Lib.Events
@@ -19,13 +18,13 @@ import           Lib.Events
 
 handleWorkerEvent :: Integer -> BChan AppEvent -> WorkerEvent -> IO ()
 handleWorkerEvent logLookbackMin brickQueue = \case
-    GetLogStreams lg -> case lg ^. lgLogGroupName of
+    GetLogStreams lg -> case lg ^. logGroup_logGroupName of
         Nothing -> return ()
         Just lgName ->
             getLogStreams lgName (100 :: Int)
                 >>= writeBChan brickQueue
                 .   SetLogStreams
-    GetLogEvents lg -> case lg ^. lgLogGroupName of
+    GetLogEvents lg -> case lg ^. logGroup_logGroupName of
         Nothing     -> return ()
         Just lgName -> do
             end <- getCurrentTime
@@ -35,7 +34,7 @@ handleWorkerEvent logLookbackMin brickQueue = \case
             getLogEvents lgName 100 (start, end) "\" 500 - \""
                 >>= writeBChan brickQueue
                 .   SetLogEvents
-    GetEventContext lg fle -> case lg ^. lgLogGroupName of
+    GetEventContext lg fle -> case lg ^. logGroup_logGroupName of
         Nothing -> return ()
         Just lgName ->
             getEventContext lgName fle 15

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
 ---
 
 resolver:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/22.yaml
 
 packages:
     - .
 
-extra-deps:
-    - amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
-    - unliftio-core-0.1.2.0@sha256:b0a7652ffce2284a6cebe05c99eb60573a8fb6631163f34b0b30a80b4a78cb23,1081
+# extra-deps:
+#     - amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
+#     - unliftio-core-0.1.2.0@sha256:b0a7652ffce2284a6cebe05c99eb60573a8fb6631163f34b0b30a80b4a78cb23,1081

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,25 +3,11 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
+packages: []
 snapshots:
-- original:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
-  completed:
-    sha256: 63539429076b7ebbab6daa7656cfb079393bf644971156dc349d7c0453694ac2
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/18.yaml
-    size: 586296
-packages:
-- original:
-    hackage: amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
-  completed:
-    pantry-tree:
-      sha256: d792656a70ee42df262a599bc6608bda069e33092d665c3438a6eeeaf7db4fb2
-      size: 992
-    hackage: amazonka-1.6.1@sha256:f58b63e83876f93aa03c54e54b3eb8ba9358af93819d41f4a5a8f8b7d8b8399c,3544
-- original:
-    hackage: unliftio-core-0.1.2.0@sha256:b0a7652ffce2284a6cebe05c99eb60573a8fb6631163f34b0b30a80b4a78cb23,1081
-  completed:
-    pantry-tree:
-      sha256: 9d970bf5f98e68e8fc129b04d6c9d8eb1e641c7556ffd0f0a168a259335b6fd7
-      size: 328
-    hackage: unliftio-core-0.1.2.0@sha256:b0a7652ffce2284a6cebe05c99eb60573a8fb6631163f34b0b30a80b4a78cb23,1081
+- completed:
+    sha256: 4be1ca5d31689b524a7f0f17a439bbe9136465213edc498e9a395899a670f2aa
+    size: 718486
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/22.yaml
+  original:
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/22.yaml


### PR DESCRIPTION
This MR makes the minimal changes to get `cloudwatcher` working with GHC965. The Stackage snapshot has been updated and a Nix flake has been added to allow nix builds. You can now also install and run the application with `nix` via:

```
nix run github:solomon-b/cloudwatcher
```